### PR TITLE
Nojira validate catalog if

### DIFF
--- a/tap_mavenlink/streams/base.py
+++ b/tap_mavenlink/streams/base.py
@@ -24,9 +24,10 @@ class BaseStream(base):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self.stream_metadata = get_stream_metadata(self.catalog.to_dict())
-        self.replication_method = self.stream_metadata.get('replication-method')
-        self.replication_key = self.stream_metadata.get('replication-key')
+        if self.catalog:
+            self.stream_metadata = get_stream_metadata(self.catalog.to_dict())
+            self.replication_method = self.stream_metadata.get('replication-method')
+            self.replication_key = self.stream_metadata.get('replication-key')
 
     def get_extra(self, parent_id):
         return {}

--- a/tap_mavenlink/utils.py
+++ b/tap_mavenlink/utils.py
@@ -30,25 +30,27 @@ def validate_args(args):
             except ValueError:
                 raise ValueError("Unable to parse as datetime.")
 
-    streams = args.catalog.to_dict()['streams']
+    if args.catalog:
 
-    for stream in streams:
-        metadata = get_stream_metadata(stream)
-        replication_method = metadata.get('replication-method')
-        replication_key = metadata.get('replication-key')
+        streams = args.catalog.to_dict()['streams']
 
-        if replication_key is not None and not isinstance(replication_key, str):
-            raise ValueError(f"Replication key cannot be a composite key; "
-                             f"got {replication_key} for stream {stream}")
+        for stream in streams:
+            metadata = get_stream_metadata(stream)
+            replication_method = metadata.get('replication-method')
+            replication_key = metadata.get('replication-key')
 
-        if replication_method not in ['INCREMENTAL', 'FULL_TABLE', None]:
-            raise ValueError(f"Unknown replication method: {replication_method} for stream {stream}")
+            if replication_key is not None and not isinstance(replication_key, str):
+                raise ValueError(f"Replication key cannot be a composite key; "
+                                 f"got {replication_key} for stream {stream}")
 
-        if replication_method == 'INCREMENTAL' and replication_key is None:
-            raise ValueError(f"Missing replication key for replication key INCREMENTAL for stream {stream}")
+            if replication_method not in ['INCREMENTAL', 'FULL_TABLE', None]:
+                raise ValueError(f"Unknown replication method: {replication_method} for stream {stream}")
 
-        if replication_method in ['FULL_TABLE', None] and replication_key is not None:
-            raise ValueError(f"Unexpected replication key found: {replication_key} for stream {stream}")
+            if replication_method == 'INCREMENTAL' and replication_key is None:
+                raise ValueError(f"Missing replication key for replication key INCREMENTAL for stream {stream}")
+
+            if replication_method in ['FULL_TABLE', None] and replication_key is not None:
+                raise ValueError(f"Unexpected replication key found: {replication_key} for stream {stream}")
 
     return args
 


### PR DESCRIPTION
# Description of change
NOJIRA Validate catalog if exists. 
Otherwise we get an error when the tap is run in discovery mode:

```
CRITICAL 'NoneType' object has no attribute 'to_dict'
Traceback (most recent call last):
  File "./.venv/tap/bin/tap-mavenlink", line 8, in <module>
    sys.exit(main())
  File "/Users/graham.jackson/code/data-connector-mavenlink/.venv/tap/lib/python3.7/site-packages/singer/utils.py", line 192, in wrapped
    return fnc(*args, **kwargs)
  File "/Users/graham.jackson/code/data-connector-mavenlink/.venv/tap/lib/python3.7/site-packages/tap_mavenlink/__init__.py", line 46, in main
    args = validate_args(args)
  File "/Users/graham.jackson/code/data-connector-mavenlink/.venv/tap/lib/python3.7/site-packages/tap_mavenlink/utils.py", line 33, in validate_args
    streams = args.catalog.to_dict()['streams']
AttributeError: 'NoneType' object has no attribute 'to_dict'
```

# QA steps
 - [y] manual qa steps passing (list below)
 Pytest passes locally
 
# Risks

# Rollback steps
 - revert this branch
