### PR TITLE
DB-183 Neverending story, changed schema from: <anyOf(string, array)> to: <string>

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,18 +21,29 @@ help : Makefile
 	@sed -n 's/^##//p' $<
 
 ## build                   : PHONY, builds distribution
-## upload                  : PHONY, uploads to internal pypiserver
-## test                    : PHONY, runs pytest
 build: tmp/.sentinel.build
+## upload                  : PHONY, uploads to internal pypiserver
 upload: tmp/.sentinel.upload
+## test                    : PHONY, runs pytest
 test: tmp/.sentinel.test
+## discover                : PHONY, runs the tap in discovery mode
+discover: tmp/.sentinel.venv-dev
+	@echo '{'                                 >  fake_config.json
+	echo  '  "token"     : "fake_token",'     >> fake_config.json
+	echo  '  "user_agent": "fake_user_agent"' >> fake_config.json
+	echo  '}'                                 >> fake_config.json
+	$(VENV_DEV)/bin/tap-mavenlink --config fake_config.json --discover
+	rm fake_config.json
 
-## clean                   : PHONY, removes virtual environments
+## clean                   : PHONY, removes sentinel and build files
 clean:
 	rm -rf tmp
 	rm -rf dist
 	rm -rf build
 	rm -rf *.egg-info
+
+## clean-hard              : PHONY, removes virtual environments
+clean-hard:
 	rm -rf $(VENV)
 
 # Install

--- a/Makefile
+++ b/Makefile
@@ -42,8 +42,8 @@ clean:
 	rm -rf build
 	rm -rf *.egg-info
 
-## clean-hard              : PHONY, removes virtual environments
-clean-hard:
+## clean-hard              : PHONY, removes sentinel and build files, and virtual environments
+clean-hard: clean
 	rm -rf $(VENV)
 
 # Install

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='data-tap-mavenlink',
-      version='0.2.0',
+      version='0.2.1',
       description='Singer.io tap for extracting data from the Mavenlink API',
       author='Fishtown Analytics',
       url='http://fishtownanalytics.com',

--- a/tap_mavenlink/schemas/story_custom_field_values.json
+++ b/tap_mavenlink/schemas/story_custom_field_values.json
@@ -70,15 +70,8 @@
             "format": "date-time"
         },
         "value": {
-            "anyOf": [
-                {
-                    "type": "array",
-                    "items": { "type": "integer" }
-                },
-                {
-                    "type": "string"
-                }
-            ]
+            "type": ["null", "string"],
+            "description": "The value applied to the subject."
         }
     }
 }

--- a/tap_mavenlink/schemas/user_custom_field_values.json
+++ b/tap_mavenlink/schemas/user_custom_field_values.json
@@ -70,15 +70,8 @@
             "format": "date-time"
         },
         "value": {
-            "anyOf": [
-                {
-                    "type": "array",
-                    "items": { "type": "integer" }
-                },
-                {
-                    "type": "string"
-                }
-            ]
+            "type": ["null", "string"],
+            "description": "The value applied to the subject."
         }
     }
 }

--- a/tests/test_catalog_discovered.py
+++ b/tests/test_catalog_discovered.py
@@ -7,11 +7,10 @@ from tests import constants
 from tap_mavenlink import main
 
 
-EXPECTED_CATALOG_DISCOVERED_CONTENT = './tests/catalog-discovered.json'
 EXPECTED_CATALOG_SCHEMA_CONTENT = './tests/catalog-schema.json'
 
 
-def test_discover_no_catalog(tmp_path, config, capsys):
+def test_catalog_discovered_schema_correct(tmp_path, config, capsys):
     # Given
     sys_args = [
         'tap-mavenlink',
@@ -26,12 +25,8 @@ def test_discover_no_catalog(tmp_path, config, capsys):
     captur = capsys.readouterr()
     catalog_discovered = json.loads(captur.out)
 
-    with open(EXPECTED_CATALOG_DISCOVERED_CONTENT, 'r') as f:
-        expected_catalog_discovered = json.loads(f.read())
-
     with open(EXPECTED_CATALOG_SCHEMA_CONTENT, 'r') as f:
         expected_catalog_schema = json.loads(f.read())
 
     # Then
-    assert catalog_discovered == expected_catalog_discovered
-    jsonschema.validate(expected_catalog_discovered, expected_catalog_schema)
+    jsonschema.validate(catalog_discovered, expected_catalog_schema)


### PR DESCRIPTION
Making custom_field_values schemas consistent for subject user, story along with already existing workspace. The `value` property is now considered of type `string` even though there are records in Mavenlink where values are arrays of integers. We decide we will exclude them from replication in any further target process.

Also we rename `test_discover.py` to `test_catalog_discover.py` to be more explicit about the fact that this test is about the catalog.