### PR TITLE
Db 222 add test for empty api response

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='data-tap-mavenlink',
-      version='0.2.1',
+      version='0.2.2',
       description='Singer.io tap for extracting data from the Mavenlink API',
       author='Fishtown Analytics',
       url='http://fishtownanalytics.com',

--- a/tap_mavenlink/streams/base.py
+++ b/tap_mavenlink/streams/base.py
@@ -70,6 +70,10 @@ class BaseStream(base):
 
         while True:
             result = self.client.make_request(url, self.API_METHOD, params=params)
+
+            if result['count'] == 0:
+                break
+
             transformed = self.get_stream_data(result, extra)
 
             with singer.metrics.record_counter(endpoint=table) as counter:

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -360,8 +360,6 @@ class TestComponent:
         """{"type": "RECORD", "stream": "fake_full_table_stream", "record": {"updated_at": "2012-01-01T00:00:00Z"}}\n""" \
             .strip(), "expect the full stdout to look like this"
 
-        assert captured.err == "", "expect empty error stream"
-
     def test_component_incremental_stream_api_response_contains_no_new_results(
             self, mock_requests, tmp_path, config, catalog, state, capsys, monkeypatch
     ):
@@ -392,4 +390,3 @@ class TestComponent:
         """{"type": "SCHEMA", "stream": "fake_incremental_stream", "schema": {"properties": {"id": {"type": "string"}, "updated_at": {"format": "date-time", "type": "string"}}, "selected": true}, "key_properties": ["id"]}\n""", \
             "expect the full stdout to look like this"
 
-        assert captured.err == "", "expect empty error stream"

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -360,6 +360,8 @@ class TestComponent:
         """{"type": "RECORD", "stream": "fake_full_table_stream", "record": {"updated_at": "2012-01-01T00:00:00Z"}}\n""" \
             .strip(), "expect the full stdout to look like this"
 
+        assert captured.err == "", "expect empty error stream"
+
     def test_component_incremental_stream_api_response_contains_no_new_results(
             self, mock_requests, tmp_path, config, catalog, state, capsys, monkeypatch
     ):
@@ -384,4 +386,10 @@ class TestComponent:
             main()
 
         # Then
-        # TBC
+        # We see a SCHEMA message, but no RECORD or STATE messages.
+        captured = capsys.readouterr()
+        assert captured.out == \
+        """{"type": "SCHEMA", "stream": "fake_incremental_stream", "schema": {"properties": {"id": {"type": "string"}, "updated_at": {"format": "date-time", "type": "string"}}, "selected": true}, "key_properties": ["id"]}\n""", \
+            "expect the full stdout to look like this"
+
+        assert captured.err == "", "expect empty error stream"


### PR DESCRIPTION
# Description of change
Add failing test and fix for the case where, for an incremental stream, there has been no new data added since the tap was last run.

# QA steps
 - [y] manual qa steps passing (list below)
All tests pass locally.
 
# Risks

# Rollback steps
 - revert this branch
